### PR TITLE
Currently, setting the backend option doesn't propagate

### DIFF
--- a/templates/confd.toml.erb
+++ b/templates/confd.toml.erb
@@ -2,6 +2,9 @@ confdir = "<%= @confdir %>"
 <% if @prefix -%>
 prefix = "<%= @prefix %>"
 <% end -%>
+<% if @backend -%>
+backend = "<%= @backend %>"
+<% end -%>
 <% if @interval -%>
 interval = <%= @interval %>
 <% end -%>

--- a/templates/confd.toml.erb
+++ b/templates/confd.toml.erb
@@ -1,4 +1,3 @@
-[confd]
 confdir = "<%= @confdir %>"
 <% if @prefix -%>
 prefix = "<%= @prefix %>"


### PR DESCRIPTION
to the generated confd.toml