### PR TITLE
Currently, the watch option to confd isn't supported.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ class confd(
   $scheme      = undef,
   $srv_domain  = undef,
   $verbose     = undef,
-
+  $watch       = undef,
   $resources = {},
 
 ) inherits confd::params {
@@ -42,6 +42,7 @@ class confd(
   if $scheme { validate_re($scheme, '^https?$') }
   if $srv_domain { validate_string($srv_domain) }
   if $verbose { validate_bool($verbose) }
+  if $watch { validate_bool($watch) }
   if $client_cert {
     validate_string($client_cert)
     $client_cert_path = "${confdir}/ssl/${client_cert}"

--- a/templates/confd.toml.erb
+++ b/templates/confd.toml.erb
@@ -20,6 +20,9 @@ srv_domain = "<%= @srv_domain %>"
 <% if @verbose != nil -%>
 verbose = <%= @verbose %>
 <% end -%>
+<% if @watch != nil -%>
+watch = <%= @watch %>
+<% end -%>
 <% if @nodes -%>
 nodes = [
 <% @nodes.each do |node| -%>

--- a/templates/confd.toml.erb
+++ b/templates/confd.toml.erb
@@ -1,4 +1,3 @@
-[confd]
 confdir = "<%= @confdir %>"
 <% if @prefix -%>
 prefix = "<%= @prefix %>"


### PR DESCRIPTION
This adds it to confd.toml if specified