### PR TITLE
added downloadurl parameter to support pulling the binary from a remo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Absolute path: defaults to `/etc/confd/`
 
 Description: Specifies where all the configuration for confd will live
 
+#####`downloadurl`
+
+URL: defaults to `undef`.
+
+Description: If set, the confd binary will be downloaded from this url instead of being taken from the sitemodule. Currently requires that the `version` parameter is set to the actual value reported by `confd --version` to ensure we have the required binary in place (the default `latest` value should be changed).
+
 ##### Other Parameters
 
 All other parameters are directly mapped to the configuration in `confd.toml` please see the [documentation](https://github.com/kelseyhightower/confd/blob/master/docs/configuration-guide.md) for full details.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class confd(
   $version       = $confd::params::version,
   $installdir    = $confd::params::installdir,
   $sitemodule    = $confd::params::sitemodule,
+  $downloadurl   = $confd::params::downloadurl,
 
   $confdir       = $confd::params::confdir,
   $nodes         = $confd::params::nodes,
@@ -34,6 +35,7 @@ class confd(
   validate_absolute_path($confdir)
   validate_hash($resources)
 
+  if $downloadurl { validate_string($downloadurl) }
   if $backend { validate_re($backend, ['^etcd$', '^consul$', '^zookeeper$', '^dynamodb$', '^redis$', '^env$']) }
   if $debug { validate_bool($debug) }
   if $interval { validate_re($interval, '^\d+') }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,12 +4,26 @@ class confd::install {
   include confd
 
   $binary_src = "puppet:///modules/${confd::sitemodule}/confd-${confd::version}"
+  $binary_dst = "${confd::installdir}/confd"
 
-  file { "${confd::installdir}/confd":
-    ensure => present,
-    links  => follow,
-    owner  => 'root',
-    mode   => '0750',
-    source => $binary_src
+  $owner = 'root'
+  $mode = '0750'
+  $links = 'follow'
+
+  if $confd::downloadurl {
+    confd::remote_file { $binary_dst:
+      url => $confd::downloadurl,
+      links => $links,
+      owner => $owner,
+      mode  => $mode,
+    }
+  } else {
+    file { $binary_dst: 
+      ensure  => present,
+      source => $binary_src,
+      links => $links,
+      owner => $owner,
+      mode  => $mode,
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class confd::params {
   $user       = 'root'
   $sitemodule = 'site_confd'
   $nodes      = ['127.0.0.1:4001']
+  $downloadurl = undef
 
   case $::osfamily {
     'Debian': {

--- a/manifests/remote_file.pp
+++ b/manifests/remote_file.pp
@@ -1,0 +1,23 @@
+# == Resource confd::remote_file
+#
+define confd::remote_file($url, $owner='root', $mode='0750', $links='follow') {
+
+  include confd
+
+  $wget_cmd = "/usr/bin/wget -q"
+  $exists_check = "/usr/bin/test -f ${title}"
+  $version_check = "/usr/bin/test `${title} --version | awk '{print \$2}'` = '${confd::version}'"
+
+  exec { "download_${title}":
+    command => "${wget_cmd} ${url} -O ${title}",
+    unless => "${exists_check} && ${version_check}"
+  }
+
+  file { $title:
+    ensure => present,
+    mode => $mode,
+    owner => $owner,
+    links => $links,
+    require => Exec["download_${title}"],
+  }
+}


### PR DESCRIPTION
I've added another parameter called `downloadurl`, which if set, will attempt to pull the binary from a URL. This is done mostly in order to avoid placing confd's binary inside the site module.

Once set, wget will be used to pull the binary - unless it already exists and `confd --version` reports the same version number as set by `$confd::version`.

Tested this on CentOS 6.5 and Ubuntu 14.04.